### PR TITLE
Also create a dark mode version of the banner logo.

### DIFF
--- a/iris/logo/generate_logo.py
+++ b/iris/logo/generate_logo.py
@@ -480,61 +480,65 @@ def _svg_logos(
 
     ###########################################################################
     # Make the banner SVG, incorporating the logo SVG.
-    banner_root = _SvgNamedElement("banner", "svg")
-    for dimension, name in enumerate(("width", "height")):
-        banner_root.attrib[name] = str(banner_size_xy[dimension])
+    for dark in (False, True):
+        banner_root = _SvgNamedElement("banner", "svg")
+        for dimension, name in enumerate(("width", "height")):
+            banner_root.attrib[name] = str(banner_size_xy[dimension])
 
-    banner_desc = ET.Element("desc")
-    banner_desc.text = (
-        "Banner logo for the SciTools Iris project - "
-        "https://github.com/SciTools/iris/"
-    )
-    banner_root.insert(0, banner_desc)
+        banner_desc = ET.Element("desc")
+        banner_desc.text = (
+            "Banner logo for the SciTools Iris project - "
+            "https://github.com/SciTools/iris/"
+        )
+        banner_root.insert(0, banner_desc)
 
-    # Left-align the logo.
-    banner_logo.attrib["preserveAspectRatio"] = "xMinYMin meet"
-    banner_root.append(banner_logo)
+        # Left-align the logo.
+        banner_logo.attrib["preserveAspectRatio"] = "xMinYMin meet"
+        banner_root.append(banner_logo)
 
-    # Text element(s).
-    banner_height = banner_size_xy[1]
-    text_size = banner_height * TEXT_GLOBE_RATIO
-    text_x = banner_size_xy[0] - (banner_height / 16)
-    # Manual y centring since SVG dominant-baseline not widely supported.
-    text_y = banner_height - (banner_height - text_size) / 2
-    text_y *= 0.975  # Slight offset
-    text_common_attrib = {
-        "x": str(text_x),
-        "fill": "#156475",
-        "font-family": "georgia",
-        "text-anchor": "end",
-    }
+        # Text element(s).
+        banner_height = banner_size_xy[1]
+        text_size = banner_height * TEXT_GLOBE_RATIO
+        text_x = banner_size_xy[0] - (banner_height / 16)
+        # Manual y centring since SVG dominant-baseline not widely supported.
+        text_y = banner_height - (banner_height - text_size) / 2
+        text_y *= 0.975  # Slight offset
+        text_common_attrib = {
+            "x": str(text_x),
+            "fill": ("#aec928" if dark else "#156475"),
+            "font-family": "georgia",
+            "text-anchor": "end",
+        }
 
-    text_element = _SvgNamedElement(
-        "text",
-        "text",
-        attrib=dict(
-            {"y": str(text_y), "font-size": f"{text_size}pt"},
-            **text_common_attrib,
-        ),
-    )
-    text_element.text = banner_text
-    banner_root.append(text_element)
-
-    if banner_version is not None:
-        version_size = text_size / 6
-        version_y = text_y + version_size + (banner_height / 16)
-        version_element = _SvgNamedElement(
-            "version",
+        text_element = _SvgNamedElement(
+            "text",
             "text",
             attrib=dict(
-                {"y": str(version_y), "font-size": f"{version_size}pt"},
+                {"y": str(text_y), "font-size": f"{text_size}pt"},
                 **text_common_attrib,
             ),
         )
-        version_element.text = banner_version
-        banner_root.append(version_element)
+        text_element.text = banner_text
+        banner_root.append(text_element)
 
-    result[f"logo-title"] = banner_root
+        if banner_version is not None:
+            version_size = text_size / 6
+            version_y = text_y + version_size + (banner_height / 16)
+            version_element = _SvgNamedElement(
+                "version",
+                "text",
+                attrib=dict(
+                    {"y": str(version_y), "font-size": f"{version_size}pt"},
+                    **text_common_attrib,
+                ),
+            )
+            version_element.text = banner_version
+            banner_root.append(version_element)
+
+        logo_key = "logo-title"
+        if dark:
+            logo_key += "-dark"
+        result[logo_key] = banner_root
 
     ###########################################################################
 


### PR DESCRIPTION
I tried using a dark-mode-sensitive logo based on [this example](https://blog.tomayac.com/2019/09/21/prefers-color-scheme-in-svg-favicons-for-dark-mode-icons/), but this did not have the desired effect within PyData Sphinx Theme (although it worked with some other web pages).

Using two different logos is clearly the intended way of achieving this in PyData Sphinx Theme ([see docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/configuring.html#different-logos-for-light-and-dark-mode)), so I've adapted the logo generation to make both versions of the banner logo, just with different colour text.